### PR TITLE
Remove duplicate "Shift"

### DIFF
--- a/usr/share/regolith/common/config.d/40_workspace-config
+++ b/usr/share/regolith/common/config.d/40_workspace-config
@@ -56,7 +56,7 @@ bindsym $mod+$wm.binding.fullscreen_toggle fullscreen toggle
 
 ## Modify // Window Floating Toggle // <><Shift> f ##
 set_from_resource $wm.binding.float_toggle wm.binding.float_toggle Shift+f
-bindsym $mod+Shift+$wm.binding.float_toggle floating toggle
+bindsym $mod+$wm.binding.float_toggle floating toggle
 
 ## Modify // Move to Scratchpad // <><Ctrl> m ##
 set_from_resource $wm.binding.move_scratchpad wm.binding.move_scratchpad Ctrl+m


### PR DESCRIPTION
`wm.binding.float_toggle` is already equal to `Shift+f`. So there is no need to have a `Shift` in `bindsym $mod+Shift+$wm.binding.float_toggle`. Because of this duplicate `Shift`, we cannot have the keyboard shortcut `$mod+f` for toggling floating.

In my case, I would like to have:
- `$mod+f` for toggling floating
- `$mod+Shift+f` for toggling full-screen