### PR TITLE
[15_base_launchers] add vm.program.terminal

### DIFF
--- a/usr/share/regolith/common/config.d/15_base_launchers
+++ b/usr/share/regolith/common/config.d/15_base_launchers
@@ -4,7 +4,8 @@
 
 ## Launch // Terminal // <> Enter ##
 set_from_resource $wm.binding.terminal wm.binding.terminal Return
-bindsym $mod+$wm.binding.terminal exec --no-startup-id /usr/bin/x-terminal-emulator
+set_from_resource $wm.program.terminal wm.program.terminal /usr/bin/x-terminal-emulator
+bindsym $mod+$wm.binding.terminal exec --no-startup-id $wm.program.terminal
 
 ## Launch // Browser // <><Shift> Enter ##
 set_from_resource $wm.binding.browser wm.binding.browser Shift+Return

--- a/usr/share/regolith/common/config.d/15_base_launchers
+++ b/usr/share/regolith/common/config.d/15_base_launchers
@@ -9,4 +9,5 @@ bindsym $mod+$wm.binding.terminal exec --no-startup-id $wm.program.terminal
 
 ## Launch // Browser // <><Shift> Enter ##
 set_from_resource $wm.binding.browser wm.binding.browser Shift+Return
-bindsym $mod+$wm.binding.browser exec --no-startup-id gtk-launch $(xdg-settings get default-web-browser)
+set_from_resource $wm.program.browser wm.program.browser gtk-launch $(xdg-settings get default-web-browser)
+bindsym $mod+$wm.binding.browser exec --no-startup-id $wm.program.browser


### PR DESCRIPTION
`vm.program.terminal` and `vm.program.browser` were missing and this could be usefull, preventing duplicating the file to user configuration