### PR TITLE
Remove `i3` references in resource names and comments in sway config files

### DIFF
--- a/usr/share/regolith/sway/config.d/42_gtklock
+++ b/usr/share/regolith/sway/config.d/42_gtklock
@@ -1,4 +1,4 @@
 ## Session // Lock Screen // <> Escape ##
-set_from_resource $i3-wm.binding.lock i3-wm.binding.lock Escape
-set_from_resource $i3-wm.program.lock i3-wm.program.lock gtklock --background $(trawlcat regolith.lockscreen.wallpaper.file /dev/null)
-bindsym $mod+$i3-wm.binding.lock exec $i3-wm.program.lock
+set_from_resource $wm.binding.lock wm.binding.lock Escape
+set_from_resource $wm.program.lock wm.program.lock gtklock --background $(trawlcat regolith.lockscreen.wallpaper.file /dev/null)
+bindsym $mod+$wm.binding.lock exec $wm.program.lock

--- a/usr/share/regolith/sway/config.d/55_session_keybindings
+++ b/usr/share/regolith/sway/config.d/55_session_keybindings
@@ -13,7 +13,7 @@ bindsym $mod+$wm.binding.exit_app [con_id="__focused__"] kill
 set_from_resource $wm.binding.kill_app wm.binding.kill_app q
 bindsym $mod+$alt+$wm.binding.kill_app [con_id="__focused__"] exec --no-startup-id kill -9 $(xdotool getwindowfocus getwindowpid)
 
-## Session // Reload i3 Config // <><Shift> c ##
+## Session // Reload sway Config // <><Shift> c ##
 set_from_resource $wm.binding.reload wm.binding.reload Shift+c
 bindsym $mod+$wm.binding.reload exec $send_reload_pending_tick && swaymsg reload
 


### PR DESCRIPTION
Fixes https://github.com/orgs/regolith-linux/discussions/903