### PR TITLE
feat: use mate-polkit instead of gnome-authentication-agent for polkit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+regolith-wm-config (4.4.3) jammy; urgency=medium
+
+  [ Soumya Ranjan Patnaik ]
+  * feat: use mate-polkit instead of gnome-authentication-agent for polkit
+
+ -- Soumya Ranjan Patniak <soumyaranjan1812@gmail.com>  Fri, 19 Jan 2024 03:13:30 +0530
+
 regolith-wm-config (4.4.2) jammy; urgency=medium
 
   [ Soumya Ranjan Patnaik ]

--- a/debian/control
+++ b/debian/control
@@ -335,7 +335,7 @@ Description: Configuration for providing media key functionality
 Package: regolith-sway-polkit
 Architecture: any
 Depends: ${misc:Depends},
-    policykit-1-gnome,
+    mate-polkit,
     regolith-wm-config
 Description: Configuration for providing media key functionality
 

--- a/usr/share/regolith/sway/config.d/85_polkit
+++ b/usr/share/regolith/sway/config.d/85_polkit
@@ -1,1 +1,1 @@
-exec env GDK_BACKEND=x11 /usr/lib/policykit-1-gnome/polkit-gnome-authentication-agent-1  
+exec /usr/libexec/polkit-mate-authentication-agent-1


### PR DESCRIPTION
The gnome auth agent for polkit crashes in native wayland and is [no longer maintained](https://gitlab.gnome.org/Archive/policykit-gnome). The sway session currently runs it under XWayland. The PR replaces it with `mate-polkit` which is actively maintained and has support for wayland. 