### PR TITLE
feat: notify systemd about successful session activation

### DIFF
--- a/etc/regolith/i3/config
+++ b/etc/regolith/i3/config
@@ -141,3 +141,6 @@ include $HOME/.config/regolith3/common-wm/config.d/*
 
 # Include any user i3 partials
 include $HOME/.config/regolith3/i3/config.d/*
+
+# Notify systemd about successful session start
+exec systemd-notify --ready

--- a/etc/regolith/sway/config
+++ b/etc/regolith/sway/config
@@ -164,3 +164,6 @@ include $HOME/.config/regolith3/common-wm/config.d/*
 
 # Include any user wm partials
 include $HOME/.config/regolith3/sway/config.d/*
+
+# Notify systemd about successful session start
+exec systemd-notify --ready


### PR DESCRIPTION
Ensure the session gets activated by sending READY to systemd. Without this, the session would automatically be quit after timeout. 

Related to regolith-linux/regolith-session#31