### PR TITLE
Import `XDG_CURRENT_DESKTOP` environment into systemd and dbus-activation environment 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -151,6 +151,12 @@ Description: Desktop executor
  Manage apps, commands, notifications, keybindings, and
  windows with this utility.
 
+Package: regolith-i3-dbus-activation
+Architecture: any
+Depends: ${misc:Depends},
+  regolith-wm-config
+Description: Regolith dbus activation
+
 Package: regolith-sway-ilia
 Architecture: any
 Depends: ${misc:Depends},

--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Package: regolith-i3-root-config
 Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config,
+  regolith-i3-dbus-activation
 Recommends: regolith-i3-compositor,
   regolith-i3-control-center-regolith,
   regolith-i3-default-style,
@@ -49,10 +50,10 @@ Package: regolith-sway-root-config
 Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config,
+  regolith-sway-dbus-activation
 Recommends: regolith-sway-audio-idle-inhibit,
   regolith-sway-background,
   regolith-sway-control-center-regolith,
-  regolith-sway-dbus-activation,
   regolith-sway-default-style,
   regolith-sway-gaps,
   regolith-sway-gsd,

--- a/debian/regolith-i3-dbus-activation.install
+++ b/debian/regolith-i3-dbus-activation.install
@@ -1,0 +1,1 @@
+usr/share/regolith/i3/config.d/10_dbus-activation

--- a/usr/share/regolith/i3/config.d/10_dbus-activation
+++ b/usr/share/regolith/i3/config.d/10_dbus-activation
@@ -1,0 +1,3 @@
+exec systemctl --user import-environment XDG_CURRENT_DESKTOP DISPLAY I3SOCK
+exec hash dbus-update-activation-environment 2>/dev/null && \
+     dbus-update-activation-environment --systemd XDG_CURRENT_DESKTOP DISPLAY I3SOCK

--- a/usr/share/regolith/sway/config.d/10_dbus-activation
+++ b/usr/share/regolith/sway/config.d/10_dbus-activation
@@ -1,3 +1,3 @@
-exec systemctl --user import-environment DISPLAY WAYLAND_DISPLAY SWAYSOCK
+exec systemctl --user import-environment XDG_CURRENT_DESKTOP DISPLAY WAYLAND_DISPLAY SWAYSOCK
 exec hash dbus-update-activation-environment 2>/dev/null && \
-     dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK
+     dbus-update-activation-environment --systemd XDG_CURRENT_DESKTOP DISPLAY WAYLAND_DISPLAY SWAYSOCK


### PR DESCRIPTION
This PR fixes an issue that causes `XDG_DESKTOP_PORTAL` to select the incorrect portal config. Also move `regolith-sway-dbus-activation` and `regolith-i3-dbus-activation` to `Depends` to ensure they're always installed.