### PR TITLE
chore: manually start regolith-wayland.target if session not started with systemd

### DIFF
--- a/etc/regolith/i3/config
+++ b/etc/regolith/i3/config
@@ -142,5 +142,8 @@ include $HOME/.config/regolith3/common-wm/config.d/*
 # Include any user i3 partials
 include $HOME/.config/regolith3/i3/config.d/*
 
-# Notify systemd about successful session start
-exec --no-startup-id systemd-notify --ready
+# Start the systemd target manually is the session is not started by systemd
+# Notify systemd about successful session start otherwise
+exec --no-startup-id [ -z "${NOTIFY_SOCKET-}" ] \
+  && systemctl --user start regolith-x11.target \
+  || systemd-notify --ready

--- a/etc/regolith/sway/config
+++ b/etc/regolith/sway/config
@@ -162,5 +162,8 @@ include $HOME/.config/regolith3/common-wm/config.d/*
 # Include any user wm partials
 include $HOME/.config/regolith3/sway/config.d/*
 
-# Notify systemd about successful session start
-exec --no-startup-id systemd-notify --ready
+# Start the systemd target manually is the session is not started by systemd
+# Notify systemd about successful session start otherwise
+exec --no-startup-id [ -z "${NOTIFY_SOCKET-}" ] \
+  && systemctl --user start regolith-wayland.target \
+  || systemd-notify --ready


### PR DESCRIPTION
This change would start the `regolith-wayland.target` and `regolith-x11.target` system units even if the session itself wasn't started with systemd. This acts as a synchronization point indicating session startup which allows other systemd services to start after the base session is initialized.

This change is required as part of an upcoming change that starts `regolith-displayd`, `regolith-inputd` and `regolith-powerd` using systemd. 