### PR TITLE
feat: remove manual startup of gsd-integrations

### DIFF
--- a/usr/share/regolith/sway/config.d/81_gsd_integrations
+++ b/usr/share/regolith/sway/config.d/81_gsd_integrations
@@ -1,12 +1,1 @@
-set_from_resource $wm.gsd.display wm.gsd.display /usr/bin/regolith-displayd-init
-set_from_resource $wm.gsd.input wm.gsd.input /usr/bin/regolith-inputd
-set_from_resource $wm.gsd.power wm.gsd.power /usr/bin/regolith-powerd
-set_from_resource $regolith.kanshi.path regolith.kanshi.path ~/.config/regolith3/kanshi
-
-exec_always bash -c "killall kanshi; kanshi -c $regolith.kanshi.path/config"
-exec $wm.gsd.display
-exec $wm.gsd.power
-exec $wm.gsd.input
-
-# Workaround for rfkill not starting on gnome-session start
-exec --no-startup-id killall gsd-rfkill && /usr/libexec/gsd-rfkill
+exec_always systemctl restart regolith-init-kanshi.service


### PR DESCRIPTION
In this commit, the exec lines for manual startup of processes that provide custom regolith implementations for gnome-settings-daemon components (`regolith-inputd`, `regolith-displayd` and `regolith-powerd`) were removed from the sway config file. The daemons still exist independently. Instead of manual startup, systemd unit files were created that start these components after `regolith-wayland.target` is started. Additionally, `regolith-init-kanshi.service` is started to ensure the display configurations are reapplied when sway reloads. This change requires the change in regolith-linux/regolith-wm-config#28 to function.