### PR TITLE
feat: restart regolith-init-kanshi service as user

### DIFF
--- a/usr/share/regolith/sway/config.d/81_gsd_integrations
+++ b/usr/share/regolith/sway/config.d/81_gsd_integrations
@@ -1,1 +1,1 @@
-exec_always systemctl restart regolith-init-kanshi.service
+exec_always systemctl restart --user regolith-init-kanshi.service


### PR DESCRIPTION
The change ensures that the kanshi service is restarted as a user instead of root.