### PR TITLE
feat(sway): add touchpad gestures support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -68,6 +68,7 @@ Recommends: regolith-sway-audio-idle-inhibit,
   regolith-sway-kbd-layout,
   regolith-sway-clamshell,
   regolith-sway-next-workspace,
+  regolith-sway-touchpad-guestures,
   regolith-sway-unclutter
 Description: Regolith sway root config file
  Basic UI configuration for sway based on Regolith's default style.
@@ -404,3 +405,9 @@ Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config
 Description: Keybindings to cycle between keyboard layotus
+
+Package: regolith-sway-touchpad-guestures
+Architecture: any
+Depends: ${misc:Depends},
+  regolith-wm-config
+Description: Configurations to enable touchpad gestures

--- a/debian/regolith-sway-touchpad-guestures.install
+++ b/debian/regolith-sway-touchpad-guestures.install
@@ -1,0 +1,1 @@
+usr/share/regolith/sway/config.d/61_touchpad_guestures

--- a/scripts/regolith-sway-clamshell
+++ b/scripts/regolith-sway-clamshell
@@ -6,6 +6,40 @@ exit_with_error() {
   exit 1
 }
 
+get_action_cmd() {
+  # Actions to take based on the value of wm.lidclose.action
+  local DEFAULT_LOCK="gtklock --background $(trawlcat regolith.lockscreen.wallpaper.file /dev/null)"
+  local LOCK=$( trawlcat wm.program.lock "$DEFAULT_LOCK")
+  local SLEEP=$( trawlcat wm.program.sleep "systemctl suspend" )
+  local HIBERNATE=$( trawlcat wm.program.hibernate "systemctl hibernate" )
+  local SHUTDOWN=$( trawlcat wm.program.shutdown "gnome-session-quit --power-off --no-prompt")
+
+  case "$1" in
+    "DO_NOTHING")
+      echo "true"
+      ;;
+
+    "LOCK")
+      echo "$LOCK"
+      ;;
+
+    "SLEEP")
+      echo "$SLEEP"
+      ;;
+
+    "HIBERNATE")
+      echo "$HIBERNATE"
+      ;;
+
+    "SHUTDOWN")
+      echo "$SHUTDOWN"
+      ;;
+
+    *)
+      exit_with_error "Invalid or missing value for resource wm.lidclose.action"
+  esac
+}
+
 INBUILT_DISPLAY=$( swaymsg -t get_outputs --raw | jq -r '[ .[] | select(.name | startswith("eDP")).name ] | .[0]' )
 
 # Early return if there is no inbuilt display
@@ -32,45 +66,16 @@ fi
 
 echo "No external display is connected."
 
-if on_ac_power; then
-  echo "On AC Power. Using action from wm.lidclose.action.power"
-  ACTION=$( trawlcat wm.lidclose.action.power "SLEEP" )
-else
-  echo "On Battery. Using action from wm.lidclose.action.battery"
-  ACTION=$( trawlcat wm.lidclose.action.battery "SLEEP" )
-fi
 
-echo "Lid close action - $ACTION"
+AC_ACTION=$( trawlcat wm.lidclose.action.power "LOCK" )
+BATTERY_ACTION=$( trawlcat wm.lidclose.action.battery "SLEEP" )
+AC_ACTION_CMD=$( get_action_cmd "$AC_ACTION" )
+BATTERY_ACTION_CMD=$( get_action_cmd "$BATTERY_ACTION" )
+ACTION_CMD="bash -c \"if on_ac_power; then $AC_ACTION_CMD; else $BATTERY_ACTION_CMD; fi\""
 
-# Actions to take based on the value of wm.lidclose.action
-DEFAULT_LOCK="gtklock --background $(trawlcat regolith.lockscreen.wallpaper.file /dev/null)"
-LOCK=$( trawlcat wm.program.lock "$DEFAULT_LOCK")
-SLEEP=$( trawlcat wm.program.sleep "systemctl suspend" )
-HIBERNATE=$( trawlcat wm.program.hibernate "systemctl hibernate" )
-SHUTDOWN=$( trawlcat wm.program.shutdown "gnome-session-quit --power-off --no-prompt")
+echo "Lid close action on Power - $AC_ACTION"
+echo "Lid close action on Battery- $BATTERY_ACTION"
 
-case "$ACTION" in
-  "DO_NOTHING")
-    swaymsg "bindswitch --locked --reload lid:on exec true"
-    ;;
 
-  "LOCK")
-    swaymsg "bindswitch --locked --reload lid:on exec $LOCK"
-    ;;
-
-  "SLEEP")
-    swaymsg "bindswitch --locked --reload lid:on exec $SLEEP"
-    ;;
-
-  "HIBERNATE")
-    swaymsg "bindswitch --locked --reload lid:on exec $HIBERNATE"
-    ;;
-
-  "SHUTDOWN")
-    swaymsg "bindswitch --locked --reload lid:on exec $SHUTDOWN"
-    ;;
-
-  *)
-    exit_with_error "Invalid or missing value for resource wm.lidclose.action"
-esac
-
+swaymsg "bindswitch --locked --reload lid:on exec '$ACTION_CMD'"
+swaymsg "bindswitch --locked --reload lid:off exec true"

--- a/usr/share/regolith/sway/config.d/61_touchpad_guestures
+++ b/usr/share/regolith/sway/config.d/61_touchpad_guestures
@@ -1,0 +1,36 @@
+###############################################################################
+# Touchpad Guesture Bindings
+###############################################################################
+
+# Three finger swipe right
+set_from_resource $wm.guesture.swipe.three_right wm.guesture.swipe.three_right workspace prev_on_output
+bindgesture --exact swipe:3:right $wm.guesture.swipe.three_right
+
+# Three finger swipe left
+set_from_resource $wm.guesture.swipe.three_left wm.guesture.swipe.three_left workspace next_on_output
+bindgesture --exact swipe:3:left $wm.guesture.swipe.three_left
+
+# Three finger swipe up
+set_from_resource $wm.guesture.swipe.three_up wm.guesture.swipe.three_up exec ilia -p windows
+bindgesture --exact swipe:3:up $wm.guesture.swipe.three_up
+
+# Three finger swipe down
+set_from_resource $wm.guesture.swipe.three_down wm.guesture.swipe.three_down exec ilia -p apps
+bindgesture --exact swipe:3:down $wm.guesture.swipe.three_down
+
+
+# Four finger swipe right
+set_from_resource $wm.guesture.swipe.four_right wm.guesture.swipe.four_right move workspace to output right
+bindgesture --exact swipe:4:right $wm.guesture.swipe.four_right
+
+# Four finger swipe left
+set_from_resource $wm.guesture.swipe.four_left wm.guesture.swipe.four_left move workspace to output left
+bindgesture --exact swipe:4:left $wm.guesture.swipe.four_left
+
+#Four finger swipe up
+set_from_resource $wm.guesture.swipe.four_up wm.guesture.swipe.four_up move workspace to output up
+bindgesture --exact swipe:4:up $wm.guesture.swipe.four_up
+
+# Four finger swipe down
+set_from_resource $wm.guesture.swipe.four_down wm.guesture.swipe.four_down move workspace to output down
+bindgesture --exact swipe:4:down $wm.guesture.swipe.four_down


### PR DESCRIPTION
This commit introduces touchpad gestures support for sway. A new package `regolith-sway-touchpad-guestures` has been added to the debian control file. This package includes a new configuration file `61_touchpad_guestures` that defines various three and four finger swipe gestures.

The default gestures included as part of this package are:
1. Three-finger swipe left/right to navigate between workspaces on the current output
2. Three-finger swipe up to open the window list page in ilia
3. Three-finger swipe down to launch the ilia apps page
4. Four-finger swipe up, down, left or right to send the current workspace to the output in that direction

@kgilmer LMK if these gestures look good or if you have any other gestures in mind that might make sense.