### PR TITLE
feat: add 3 bindings for window and screen grabs with grimshot

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -411,3 +411,10 @@ Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config
 Description: Configurations to enable touchpad gestures
+
+Package: regolith-sway-grimshot
+Architecture: any
+Depends: ${misc:Depends},
+  regolith-wm-config,
+  grimshot
+Description: Enable window and screen captures

--- a/debian/regolith-sway-grimshot.install
+++ b/debian/regolith-sway-grimshot.install
@@ -1,0 +1,1 @@
+usr/share/regolith/sway/config.d/80_grimshot

--- a/usr/share/regolith/sway/config.d/80_grimshot
+++ b/usr/share/regolith/sway/config.d/80_grimshot
@@ -1,0 +1,11 @@
+## Session // Window Snapshot // <><Prtscr> ##
+set_from_resource $wm.binding.screenshot.window wm.binding.screenshot.window Print
+bindsym $mod+$wm.binding.screenshot.window exec grimshot copy active
+
+## Session // Screenshot // <><Shift><Prtscr> ##
+set_from_resource $wm.binding.screenshot wm.binding.screenshot Shift+Print
+bindsym $mod+$wm.binding.screenshot exec grimshot --notify savecopy anything
+
+## Session // Capture All Screens // <><Shift><Ctrl><Prtscr> ##
+set_from_resource $wm.binding.screenshot.all wm.binding.screenshot.all Shift+Ctrl+Print
+bindsym $mod+$wm.binding.screenshot.all exec grimshot --notify save screen


### PR DESCRIPTION
`<super><printscr>` ~ saves active/focused window to clipboard.  No visual or audio indication
`<super><shift><printscr>` ~ grimshot "anything" mode allows selection of any elements other than "all outputs".  Saves image and writes to clipboard.  Generates notification.
`<super><shift><ctrl><printscr>` ~ captures all outputs to a file and generates a notification.