### PR TITLE
fix: update pkg name for touchpad package. remove bin package decl. a…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,22 +53,23 @@ Depends: ${misc:Depends},
   regolith-sway-dbus-activation
 Recommends: regolith-sway-audio-idle-inhibit,
   regolith-sway-background,
+  regolith-sway-clamshell,
   regolith-sway-control-center-regolith,
   regolith-sway-default-style,
   regolith-sway-gaps,
+  regolith-sway-grimshot,
   regolith-sway-gsd,
   regolith-sway-gtklock,
   regolith-sway-i3status-rs,
   regolith-sway-ilia,
+  regolith-sway-kbd-layout,
   regolith-sway-media-keys,
   regolith-sway-media-keys,
+  regolith-sway-next-workspace,
   regolith-sway-polkit,
   regolith-sway-screensharing,
   regolith-sway-session,
-  regolith-sway-kbd-layout,
-  regolith-sway-clamshell,
-  regolith-sway-next-workspace,
-  regolith-sway-touchpad-guestures,
+  regolith-sway-touchpad-gestures,
   regolith-sway-unclutter
 Description: Regolith sway root config file
  Basic UI configuration for sway based on Regolith's default style.
@@ -405,12 +406,6 @@ Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config
 Description: Keybindings to cycle between keyboard layotus
-
-Package: regolith-sway-touchpad-guestures
-Architecture: any
-Depends: ${misc:Depends},
-  regolith-wm-config
-Description: Configurations to enable touchpad gestures
 
 Package: regolith-sway-grimshot
 Architecture: any


### PR DESCRIPTION
* update pkg name for touchpad package
* remove bin package decl, that package moved to it's [own source package](https://github.com/regolith-linux/regolith-sway-touchpad-gestures) so that it could be isolated from incompatible target os releases.
* add soft dep on grimshot, new package for screen/window capture
* alpha sort deps