### PR TITLE
Support overriding more keys via resources

### DIFF
--- a/etc/regolith/i3/config
+++ b/etc/regolith/i3/config
@@ -53,16 +53,17 @@ set_from_resource $ws19 wm.workspace.19.name "19"
 # These are the keys which will be used while binding workspace switching
 ###############################################################################
 
-set_from_resource $ws1_key  wm.workspace.01.key 1
-set_from_resource $ws2_key  wm.workspace.02.key 2
-set_from_resource $ws3_key  wm.workspace.03.key 3
-set_from_resource $ws4_key  wm.workspace.04.key 4
-set_from_resource $ws5_key  wm.workspace.05.key 5
-set_from_resource $ws6_key  wm.workspace.06.key 6
-set_from_resource $ws7_key  wm.workspace.07.key 7
-set_from_resource $ws8_key  wm.workspace.08.key 8
-set_from_resource $ws9_key  wm.workspace.09.key 9
-set_from_resource $ws10_key wm.workspace.10.key 0
+set_from_resource $ws1_key     wm.workspace.01.key 1
+set_from_resource $ws2_key     wm.workspace.02.key 2
+set_from_resource $ws3_key     wm.workspace.03.key 3
+set_from_resource $ws4_key     wm.workspace.04.key 4
+set_from_resource $ws5_key     wm.workspace.05.key 5
+set_from_resource $ws6_key     wm.workspace.06.key 6
+set_from_resource $ws7_key     wm.workspace.07.key 7
+set_from_resource $ws8_key     wm.workspace.08.key 8
+set_from_resource $ws9_key     wm.workspace.09.key 9
+set_from_resource $ws10_key    wm.workspace.10.key 0
+set_from_resource $ws_high_key wm.workspace.high.key Ctrl
 
 ###############################################################################
 # Colors and Fonts

--- a/etc/regolith/sway/config
+++ b/etc/regolith/sway/config
@@ -73,16 +73,17 @@ set $ws19 "$ws19"
 # These are the keys which will be used while binding workspace switching
 ###############################################################################
 
-set_from_resource $ws1_key  wm.workspace.01.key 1
-set_from_resource $ws2_key  wm.workspace.02.key 2
-set_from_resource $ws3_key  wm.workspace.03.key 3
-set_from_resource $ws4_key  wm.workspace.04.key 4
-set_from_resource $ws5_key  wm.workspace.05.key 5
-set_from_resource $ws6_key  wm.workspace.06.key 6
-set_from_resource $ws7_key  wm.workspace.07.key 7
-set_from_resource $ws8_key  wm.workspace.08.key 8
-set_from_resource $ws9_key  wm.workspace.09.key 9
-set_from_resource $ws10_key wm.workspace.10.key 0
+set_from_resource $ws1_key     wm.workspace.01.key 1
+set_from_resource $ws2_key     wm.workspace.02.key 2
+set_from_resource $ws3_key     wm.workspace.03.key 3
+set_from_resource $ws4_key     wm.workspace.04.key 4
+set_from_resource $ws5_key     wm.workspace.05.key 5
+set_from_resource $ws6_key     wm.workspace.06.key 6
+set_from_resource $ws7_key     wm.workspace.07.key 7
+set_from_resource $ws8_key     wm.workspace.08.key 8
+set_from_resource $ws9_key     wm.workspace.09.key 9
+set_from_resource $ws10_key    wm.workspace.10.key 0
+set_from_resource $ws_high_key wm.workspace.high.key Ctrl
 
 ###############################################################################
 # Colors and Fonts

--- a/usr/share/regolith/common/config.d/30_navigation
+++ b/usr/share/regolith/common/config.d/30_navigation
@@ -34,15 +34,15 @@ bindsym $mod+$ws8_key workspace number $ws8
 bindsym $mod+$ws9_key workspace number $ws9
 bindsym $mod+$ws10_key workspace number $ws10
 ## Navigate // Workspace 11 - 19 // <><Ctrl> 1..9 ##
-bindsym $mod+Ctrl+$ws1_key workspace number $ws11
-bindsym $mod+Ctrl+$ws2_key workspace number $ws12
-bindsym $mod+Ctrl+$ws3_key workspace number $ws13
-bindsym $mod+Ctrl+$ws4_key workspace number $ws14
-bindsym $mod+Ctrl+$ws5_key workspace number $ws15
-bindsym $mod+Ctrl+$ws6_key workspace number $ws16
-bindsym $mod+Ctrl+$ws7_key workspace number $ws17
-bindsym $mod+Ctrl+$ws8_key workspace number $ws18
-bindsym $mod+Ctrl+$ws9_key workspace number $ws19
+bindsym $mod+$ws_high_key+$ws1_key workspace number $ws11
+bindsym $mod+$ws_high_key+$ws2_key workspace number $ws12
+bindsym $mod+$ws_high_key+$ws3_key workspace number $ws13
+bindsym $mod+$ws_high_key+$ws4_key workspace number $ws14
+bindsym $mod+$ws_high_key+$ws5_key workspace number $ws15
+bindsym $mod+$ws_high_key+$ws6_key workspace number $ws16
+bindsym $mod+$ws_high_key+$ws7_key workspace number $ws17
+bindsym $mod+$ws_high_key+$ws8_key workspace number $ws18
+bindsym $mod+$ws_high_key+$ws9_key workspace number $ws19
 
 ## Navigate // Next Workspace // <> Tab ##
 set_from_resource $wm.binding.ws_next wm.binding.ws_next Tab

--- a/usr/share/regolith/common/config.d/40_workspace-config
+++ b/usr/share/regolith/common/config.d/40_workspace-config
@@ -70,50 +70,53 @@ bindsym $mod+$wm.binding.focus_toggle focus mode_toggle
 set_from_resource $wm.binding.layout_mode wm.binding.layout_mode t
 bindsym $mod+$wm.binding.layout_mode layout toggle tabbed splith splitv
 
+# move focused container to workspace
+set_from_resource $wm.move_container_to_ws_key wm.move_container_to_ws_key Shift
 ## Modify // Move Window to Workspace 1 - 10 // <><Shift> 0..9 ##
-bindsym $mod+Shift+$ws1_key move container to workspace number $ws1
-bindsym $mod+Shift+$ws2_key move container to workspace number $ws2
-bindsym $mod+Shift+$ws3_key move container to workspace number $ws3
-bindsym $mod+Shift+$ws4_key move container to workspace number $ws4
-bindsym $mod+Shift+$ws5_key move container to workspace number $ws5
-bindsym $mod+Shift+$ws6_key move container to workspace number $ws6
-bindsym $mod+Shift+$ws7_key move container to workspace number $ws7
-bindsym $mod+Shift+$ws8_key move container to workspace number $ws8
-bindsym $mod+Shift+$ws9_key move container to workspace number $ws9
-bindsym $mod+Shift+$ws10_key move container to workspace number $ws10
+bindsym $mod+$wm.move_container_to_ws_key+$ws1_key move container to workspace number $ws1
+bindsym $mod+$wm.move_container_to_ws_key+$ws2_key move container to workspace number $ws2
+bindsym $mod+$wm.move_container_to_ws_key+$ws3_key move container to workspace number $ws3
+bindsym $mod+$wm.move_container_to_ws_key+$ws4_key move container to workspace number $ws4
+bindsym $mod+$wm.move_container_to_ws_key+$ws5_key move container to workspace number $ws5
+bindsym $mod+$wm.move_container_to_ws_key+$ws6_key move container to workspace number $ws6
+bindsym $mod+$wm.move_container_to_ws_key+$ws7_key move container to workspace number $ws7
+bindsym $mod+$wm.move_container_to_ws_key+$ws8_key move container to workspace number $ws8
+bindsym $mod+$wm.move_container_to_ws_key+$ws9_key move container to workspace number $ws9
+bindsym $mod+$wm.move_container_to_ws_key+$ws10_key move container to workspace number $ws10
 ## Modify // Move Window to Workspace 11 - 19// <><Ctrl><Shift> 1..9 ##
-bindsym $mod+Shift+Ctrl+$ws1_key move container to workspace number $ws11
-bindsym $mod+Shift+Ctrl+$ws2_key move container to workspace number $ws12
-bindsym $mod+Shift+Ctrl+$ws3_key move container to workspace number $ws13
-bindsym $mod+Shift+Ctrl+$ws4_key move container to workspace number $ws14
-bindsym $mod+Shift+Ctrl+$ws5_key move container to workspace number $ws15
-bindsym $mod+Shift+Ctrl+$ws6_key move container to workspace number $ws16
-bindsym $mod+Shift+Ctrl+$ws7_key move container to workspace number $ws17
-bindsym $mod+Shift+Ctrl+$ws8_key move container to workspace number $ws18
-bindsym $mod+Shift+Ctrl+$ws9_key move container to workspace number $ws19
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws1_key move container to workspace number $ws11
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws2_key move container to workspace number $ws12
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws3_key move container to workspace number $ws13
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws4_key move container to workspace number $ws14
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws5_key move container to workspace number $ws15
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws6_key move container to workspace number $ws16
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws7_key move container to workspace number $ws17
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws8_key move container to workspace number $ws18
+bindsym $mod+$wm.move_container_to_ws_key+$ws_high_key+$ws9_key move container to workspace number $ws19
 
 # move focused container to workspace, move to workspace
+set_from_resource $wm.carry_container_to_ws_key wm.carry_container_to_ws_key Mod1
 ## Modify // Carry Window to Workspace 1 - 10// <><Alt> 0..9 ##
-bindsym $mod+$alt+$ws1_key move container to workspace number $ws1; workspace number $ws1
-bindsym $mod+$alt+$ws2_key move container to workspace number $ws2; workspace number $ws2
-bindsym $mod+$alt+$ws3_key move container to workspace number $ws3; workspace number $ws3
-bindsym $mod+$alt+$ws4_key move container to workspace number $ws4; workspace number $ws4
-bindsym $mod+$alt+$ws5_key move container to workspace number $ws5; workspace number $ws5
-bindsym $mod+$alt+$ws6_key move container to workspace number $ws6; workspace number $ws6
-bindsym $mod+$alt+$ws7_key move container to workspace number $ws7; workspace number $ws7
-bindsym $mod+$alt+$ws8_key move container to workspace number $ws8; workspace number $ws8
-bindsym $mod+$alt+$ws9_key move container to workspace number $ws9; workspace number $ws9
-bindsym $mod+$alt+$ws10_key move container to workspace number $ws10; workspace number $ws10
+bindsym $mod+$wm.carry_container_to_ws_key+$ws1_key move container to workspace number $ws1; workspace number $ws1
+bindsym $mod+$wm.carry_container_to_ws_key+$ws2_key move container to workspace number $ws2; workspace number $ws2
+bindsym $mod+$wm.carry_container_to_ws_key+$ws3_key move container to workspace number $ws3; workspace number $ws3
+bindsym $mod+$wm.carry_container_to_ws_key+$ws4_key move container to workspace number $ws4; workspace number $ws4
+bindsym $mod+$wm.carry_container_to_ws_key+$ws5_key move container to workspace number $ws5; workspace number $ws5
+bindsym $mod+$wm.carry_container_to_ws_key+$ws6_key move container to workspace number $ws6; workspace number $ws6
+bindsym $mod+$wm.carry_container_to_ws_key+$ws7_key move container to workspace number $ws7; workspace number $ws7
+bindsym $mod+$wm.carry_container_to_ws_key+$ws8_key move container to workspace number $ws8; workspace number $ws8
+bindsym $mod+$wm.carry_container_to_ws_key+$ws9_key move container to workspace number $ws9; workspace number $ws9
+bindsym $mod+$wm.carry_container_to_ws_key+$ws10_key move container to workspace number $ws10; workspace number $ws10
 ## Modify // Carry Window to Workspace 11 - 19 // <><Alt><Ctrl> 1..9 ##
-bindsym $mod+$alt+Ctrl+$ws1_key move container to workspace number $ws11; workspace number $ws11
-bindsym $mod+$alt+Ctrl+$ws2_key move container to workspace number $ws12; workspace number $ws12
-bindsym $mod+$alt+Ctrl+$ws3_key move container to workspace number $ws13; workspace number $ws13
-bindsym $mod+$alt+Ctrl+$ws4_key move container to workspace number $ws14; workspace number $ws14
-bindsym $mod+$alt+Ctrl+$ws5_key move container to workspace number $ws15; workspace number $ws15
-bindsym $mod+$alt+Ctrl+$ws6_key move container to workspace number $ws16; workspace number $ws16
-bindsym $mod+$alt+Ctrl+$ws7_key move container to workspace number $ws17; workspace number $ws17
-bindsym $mod+$alt+Ctrl+$ws8_key move container to workspace number $ws18; workspace number $ws18
-bindsym $mod+$alt+Ctrl+$ws9_key move container to workspace number $ws19; workspace number $ws19
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws1_key move container to workspace number $ws11; workspace number $ws11
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws2_key move container to workspace number $ws12; workspace number $ws12
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws3_key move container to workspace number $ws13; workspace number $ws13
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws4_key move container to workspace number $ws14; workspace number $ws14
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws5_key move container to workspace number $ws15; workspace number $ws15
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws6_key move container to workspace number $ws16; workspace number $ws16
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws7_key move container to workspace number $ws17; workspace number $ws17
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws8_key move container to workspace number $ws18; workspace number $ws18
+bindsym $mod+$wm.carry_container_to_ws_key+$ws_high_key+$ws9_key move container to workspace number $ws19; workspace number $ws19
 
 set_from_resource $wm.workspace.auto_back_and_forth wm.workspace.auto_back_and_forth no
 workspace_auto_back_and_forth $wm.workspace.auto_back_and_forth


### PR DESCRIPTION
Hi. This PR makes more of the modifier keys for container and workspace movement and modification configurable via resources. So for example I can swap 'Ctrl' as the workspace 11-19 selector and 'Shift' as the move-container-to-workspace key.

I've tested this locally using i3; I don't have a sway setup but I doubt it's any different.

This also provides a fix for #3, though the "carry window to workspace" case is a bit odd because it uses `$alt` and AFAICT I can't access that directly from the default argument in `set_from_resource`, so it has to be set directly as Mod1 here.

Added:
wm.workspace.high.key for the key to reach workspaces 11-19 (default is Ctrl)
wm.move_container_to_ws_key to move containers to workspaces (default is Shift)
wm.carry_container_to_ws_key to move containers to workspaces and change to that workspace (default is Mod1)

These names aren't necessarily consistent with each other, but I tried to keep them consistent with the ones around them. Obviously they can be changed to whatever.
