### PR TITLE
fix: pull window binding definition out of partial, into root config,…

### DIFF
--- a/etc/regolith/i3/config
+++ b/etc/regolith/i3/config
@@ -136,6 +136,14 @@ set_from_resource $wm.binding.up wm.binding.up k
 set_from_resource $wm.binding.down wm.binding.down j
 
 ###############################################################################
+# Common Window Bindings
+###############################################################################
+set_from_resource $wm.binding.move_left wm.binding.move_left Shift+h
+set_from_resource $wm.binding.move_right wm.binding.move_right Shift+l
+set_from_resource $wm.binding.move_up wm.binding.move_up Shift+k
+set_from_resource $wm.binding.move_down wm.binding.move_down Shift+j
+
+###############################################################################
 # WM Config Partials
 ###############################################################################
 

--- a/etc/regolith/sway/config
+++ b/etc/regolith/sway/config
@@ -156,6 +156,14 @@ set_from_resource $wm.binding.up wm.binding.up k
 set_from_resource $wm.binding.down wm.binding.down j
 
 ###############################################################################
+# Common Window Bindings
+###############################################################################
+set_from_resource $wm.binding.move_left wm.binding.move_left Shift+h
+set_from_resource $wm.binding.move_right wm.binding.move_right Shift+l
+set_from_resource $wm.binding.move_up wm.binding.move_up Shift+k
+set_from_resource $wm.binding.move_down wm.binding.move_down Shift+j
+
+###############################################################################
 # WM Config Partials
 ###############################################################################
 

--- a/usr/share/regolith/common/config.d/40_workspace-config
+++ b/usr/share/regolith/common/config.d/40_workspace-config
@@ -9,10 +9,6 @@ bindsym $mod+Shift+Up move up
 bindsym $mod+Shift+Right move right
 
 ## Modify // Window Position // <><Shift> k j h l ##
-set_from_resource $wm.binding.move_left wm.binding.move_left Shift+h
-set_from_resource $wm.binding.move_right wm.binding.move_right Shift+l
-set_from_resource $wm.binding.move_up wm.binding.move_up Shift+k
-set_from_resource $wm.binding.move_down wm.binding.move_down Shift+j
 bindsym $mod+$wm.binding.move_left move left
 bindsym $mod+$wm.binding.move_down move down
 bindsym $mod+$wm.binding.move_up move up


### PR DESCRIPTION
… to prevent decl ordering issues. 

Analogous to a prior fix regarding the bindings "$wm.binding.down, ..." of 30_navigation, but applied to  "$wm.binding.move_down, ..." of 40_workspace-config which is also used in 50_resize-mode