### PR TITLE
fix: add gnome-control-center configs for sway

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,7 @@ Depends: ${misc:Depends},
 Recommends: regolith-sway-audio-idle-inhibit,
   regolith-sway-background,
   regolith-sway-clamshell,
-  regolith-sway-control-center-regolith,
+  regolith-sway-control-center-regolith | regolith-sway-control-center-gnome,
   regolith-sway-default-style,
   regolith-sway-gaps,
   regolith-sway-grimshot,
@@ -216,6 +216,18 @@ Conflicts: regolith-wm-gnome
 Replaces: regolith-wm-gnome
 Description: regolith and gnome integrations for system management
  Launch regolith settings app for system management.
+
+Package: regolith-sway-control-center-gnome
+Architecture: any
+Depends: ${misc:Depends},
+  regolith-wm-config,
+  gnome-control-center,
+  gnome-settings-daemon
+Provides: regolith-wm-control-center
+Conflicts: regolith-wm-gnome
+Replaces: regolith-wm-gnome
+Description: regolith and gnome integrations for system management
+ Launch gnome settings app for system management.
 
 Package: regolith-i3-control-center-gnome
 Architecture: any

--- a/debian/regolith-sway-control-center-gnome.install
+++ b/debian/regolith-sway-control-center-gnome.install
@@ -1,0 +1,1 @@
+usr/share/regolith/sway/config.d/60_gnome_config_keybindings

--- a/usr/share/regolith/sway/config.d/60_gnome_config_keybindings
+++ b/usr/share/regolith/sway/config.d/60_gnome_config_keybindings
@@ -28,6 +28,3 @@ set_from_resource $wm.program.files wm.program.files /usr/bin/nautilus --new-win
 bindsym $mod+$wm.binding.files exec --no-startup-id $wm.program.files
 
 for_window [class="gnome-control-center"] floating enable
-
-set_from_resource $wm.program.media-keys wm.program.media-keys /usr/libexec/gnome-flashback-media-keys
-exec --no-startup-id $wm.program.media-keys


### PR DESCRIPTION
This adds the configs required to use gnome control center instead of regolith control center 